### PR TITLE
Fix: Correct syntax error in documentConverter.ts

### DIFF
--- a/src/services/converters/documentConverter.ts
+++ b/src/services/converters/documentConverter.ts
@@ -157,8 +157,7 @@ async function extractTextContentFromPdf(
 		const textContent = await page.getTextContent();
 
 		// Basic text item concatenation. Might need refinement for spacing, hyphenation, etc.
-		textContent.items.forEach((item: any) // TODO: Add proper type for item if available from pdfjsLib
-			=> {
+		textContent.items.forEach((item: any) => { // TODO: Add proper type for item if available from pdfjsLib
 			fullText += item.str;
 			if (item.hasEOL) { // End of Line marker from pdf.js
 				fullText += "\n";


### PR DESCRIPTION
The build was failing due to an unexpected newline before an arrow function in the `extractTextContentFromPdf` function.

This commit moves the arrow `=>` to the same line as the parameters of the `forEach` callback function to resolve the syntax error.